### PR TITLE
fix(bitbucket): Also allow input of snippet links with more path elements

### DIFF
--- a/src/bins/engines/bitbucket.rs
+++ b/src/bins/engines/bitbucket.rs
@@ -55,7 +55,7 @@ impl Bitbucket {
 
   fn get_snippet(&self, bins: &Bins, url: &Url) -> Result<Snippet> {
     let segments: Vec<_> = some_or_err!(url.path_segments(), "url has no path".into()).collect();
-    if segments.len() != 3 || segments[0] != "snippets" {
+    if segments.len() < 3 || segments[0] != "snippets" {
       return Err("url path expected to be of form /snippets/{username}/{id}".into());
     }
     let username = segments[1];


### PR DESCRIPTION
The URLs to the individual snippets on the listing page on include a
title at the end, e.g.:

https://bitbucket.org/snippets/username/abc12/title

The previous code was too strict with that and rejected such a URL. We
now accept that too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jkcclemens/bins/22)
<!-- Reviewable:end -->
